### PR TITLE
spec: bump libxcrypt to 4.4.37

### DIFF
--- a/spec
+++ b/spec
@@ -2,7 +2,7 @@
 VER=0.1.6
 _mirror="http://pkg.loongnix.cn/loongnix"
 __GLIBC_VER=2.40
-__LIBXCRYPT_VER=4.4.36
+__LIBXCRYPT_VER=4.4.37
 
 SRCS="\
   file::rename=glibc.tar.xz::https://ftp.gnu.org/gnu/glibc/glibc-${__GLIBC_VER}.tar.xz \

--- a/spec.main
+++ b/spec.main
@@ -1,7 +1,7 @@
 VER=0.1.6
 _mirror="http://pkg.loongnix.cn/loongnix"
 __GLIBC_VER=2.40
-__LIBXCRYPT_VER=4.4.36
+__LIBXCRYPT_VER=4.4.37
 
 SRCS="\
   file::rename=glibc.tar.xz::https://ftp.gnu.org/gnu/glibc/glibc-${__GLIBC_VER}.tar.xz \


### PR DESCRIPTION
Align with Core 12.0.2, which updated `libxcrypt` to 4.4.37.

4.4.37 seems to only contain documentation and test fixes, so it shouldn't break anything - see [comparison between v4.4.36 and v4.4.37](https://github.com/besser82/libxcrypt/compare/v4.4.36...v4.4.37)